### PR TITLE
Fix colab badge links

### DIFF
--- a/tutorial_notebooks/01_Link_FEBRL_Data_with_SimSum_Classification.ipynb
+++ b/tutorial_notebooks/01_Link_FEBRL_Data_with_SimSum_Classification.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/rachhouse/intro-to-data-linking/blob/main/tutorial_notebooks/01_Link_FEBRL_Data_with_SimSum_Classification.ipynb\" target=\"_blank\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>"
+    "<a href=\"https://colab.research.google.com/github/rachhouse/intro-to-data-linking/blob/main/tutorial_notebooks/01_Link_FEBRL_Data_with_SimSum_Classification.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>"
    ]
   },
   {

--- a/tutorial_notebooks/01_Link_FEBRL_Data_with_SimSum_Classification.ipynb
+++ b/tutorial_notebooks/01_Link_FEBRL_Data_with_SimSum_Classification.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rachhouse/intro-to-data-linking/blob/main/tutorial_notebooks/01_Link_FEBRL_Data_with_SimSum_Classification.ipynb)"
+    "<a href=\"https://colab.research.google.com/github/rachhouse/intro-to-data-linking/blob/main/tutorial_notebooks/01_Link_FEBRL_Data_with_SimSum_Classification.ipynb\" target=\"_blank\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>"
    ]
   },
   {

--- a/tutorial_notebooks/02_Link_FEBRL_Data_with_ML_Classifier.ipynb
+++ b/tutorial_notebooks/02_Link_FEBRL_Data_with_ML_Classifier.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rachhouse/intro-to-data-linking/blob/main/tutorial_notebooks/02_Link_FEBRL_Data_with_ML_Classifier.ipynb)"
+    "<a href=\"https://colab.research.google.com/github/rachhouse/intro-to-data-linking/blob/main/tutorial_notebooks/02_Link_FEBRL_Data_with_ML_Classifier.ipynb\" target=\"_blank\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>"
    ]
   },
   {

--- a/tutorial_notebooks/02_Link_FEBRL_Data_with_ML_Classifier.ipynb
+++ b/tutorial_notebooks/02_Link_FEBRL_Data_with_ML_Classifier.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/rachhouse/intro-to-data-linking/blob/main/tutorial_notebooks/02_Link_FEBRL_Data_with_ML_Classifier.ipynb\" target=\"_blank\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>"
+    "<a href=\"https://colab.research.google.com/github/rachhouse/intro-to-data-linking/blob/main/tutorial_notebooks/02_Link_FEBRL_Data_with_ML_Classifier.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>"
    ]
   },
   {


### PR DESCRIPTION
Using `target="_blank"` in the Jupyter markdown cells doesn't seem to work with the GitHub notebook renderer. However, using `target="_parent"` at least resolves the blocked content errors.